### PR TITLE
fix: hide Go-To Interview Problems section when empty Fixes #71

### DIFF
--- a/src/app/companies/(company-wise)/[company-slug]/prep-guide/page.tsx
+++ b/src/app/companies/(company-wise)/[company-slug]/prep-guide/page.tsx
@@ -68,7 +68,7 @@ export default async function PrepGuidePage({
             }
         })
     ]);
-
+    
     const dataStructures: Record<string, number> = {};
     const algorithms: Record<string, number> = {};
 
@@ -101,7 +101,7 @@ export default async function PrepGuidePage({
                 <h2 className="text-xl font-medium"> Most-Frequent {sheet.name} Interview Topics</h2>
                 <TagsPieChart dataStructures={dataStructures} algorithms={algorithms} totalProblemsCount={problems.length} />
             </div>
-            <div className="p-6 border-2 border-border mb-6 bg-card flex flex-col gap-6 mt-6">
+            {favoriteProblems.length > 0 && (<div className="p-6 border-2 border-border mb-6 bg-card flex flex-col gap-6 mt-6">
                 <h2 className="text-xl font-medium">{sheet.name}&apos;s Go-To Interview Problems</h2>
                 <div className="border-t-2 border-border shadow-shadow">
                     {favoriteProblems.map((problem, idx) => (
@@ -120,7 +120,7 @@ export default async function PrepGuidePage({
                         />
                     ))}
                 </div>
-            </div>
+            </div>)}
         </div>
     );
 }


### PR DESCRIPTION
Fixes #71

## Changes
- Added conditional rendering to hide "Go-To Interview Problems" section when no problems exist
- Section now only renders when `favoriteProblems.length > 0`

## Testing
- ✅ Tested with empty favoriteProblems array (Oyo company) section is hidden.
- ✅ Linting passed with no new warnings.
- ✅ Full integration testing completed with local database setup.

## Screenshots
**Before:**
<img width="1682" height="1029" alt="Screenshot 2025-10-07 at 1 03 30 PM" src="https://github.com/user-attachments/assets/bbf2370c-5b8b-430d-b9e9-68a32606630e" />
**After:** 
<img width="1682" height="1029" alt="Screenshot 2025-10-07 at 1 04 21 PM" src="https://github.com/user-attachments/assets/cdebadad-68e3-4558-ba63-1b775ff2465e" />
